### PR TITLE
[17] Crop saved portrait after capturing image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Includes [camera app](./camera) for sending photos to be glitched.
 Includes [server](./server) for processing and sending off photos.
 
 ## Running
-_Ensure you have node.js and npm installed_
+_Ensure you have node.js and npm installed, as well as ImageMagick and maybe OpenCV?_
 
 - Run `npm install && npm start` in the `camera` directory. An Electron application will open.
 - Run `npm install && npm start` in the `client` directory. Navigate to [localhost:3001](localhost:3001) in your browser, if the script does not take you there directly.

--- a/camera/src/App.js
+++ b/camera/src/App.js
@@ -16,10 +16,6 @@ const client = socket.connect(serverUrl, socketOptions);
 const H_KEYCODE = 72;
 const SPACEBAR_KEYCODE = 32;
 
-// const subscribeToGlitch = (client, cb) => {
-//   client.on('glitch_response', response => cb(null, response));
-// };
-
 const Processing = ({ res }) => (<div style={{color: 'white'}}>
   {res ? <p>!!!!!!cool shit from adam!!!!!!</p> : <p>d'oh!</p>}
 </div>);
@@ -27,10 +23,7 @@ const Processing = ({ res }) => (<div style={{color: 'white'}}>
 export default class App extends Component {
   constructor (props) {
     super(props);
-    this.state = {
-      isGenerating: false,
-      glitchRes: false
-    };
+    this.state = { isGenerating: false };
     this.capture = this.capture.bind(this);
   }
 
@@ -79,10 +72,7 @@ export default class App extends Component {
             'xIndex': 1
           };
 
-          if (!isGenerating) {
-            client.emit('coordinates', rect);
-            console.log(JSON.stringify(rect));
-          }
+          if (!isGenerating) client.emit('coordinates', rect);
 
           return <div key={i} style={styleRectangle}>
             <Rectangle width={rect.width}
@@ -94,7 +84,7 @@ export default class App extends Component {
         })}
       </div>);
 
-    ReactDOM.render(faces, container);
+    if (!this.state.isGenerating) ReactDOM.render(faces, container);
   }
 
   componentDidMount () {
@@ -102,6 +92,11 @@ export default class App extends Component {
 
     client.on('connect', () => {
       this.client = client;
+
+      this.client.on('generating', ({ isGenerating }) => {
+        this.setState({ isGenerating });
+      });
+
       this.client.on('faces', faces => {
         this.addFaces(faces);
       });
@@ -117,7 +112,7 @@ export default class App extends Component {
     return (
       <div className='container'>
         { this.state.isGenerating
-        ? <Processing res={this.state.glitchRes} />
+        ? <Processing res={this.state.isGenerating} />
         : (<div>
           <div className='faces' />
           <div style={style}>

--- a/server/lib/gifOut.js
+++ b/server/lib/gifOut.js
@@ -2,7 +2,6 @@
 
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const writeFile = util.promisify(require('fs').writeFile);
 
 const pwd = process.cwd();
 
@@ -10,39 +9,12 @@ const processing = `processing-java --sketch=${pwd} --output=${pwd}/output --for
 const gifIt = 'gifsicle --delay=3 -O3 --loop artifacts/f*.gif > glitch.gif';
 const cleanUp = 'rm cropped.jpg';
 
-// h/t: https://stackoverflow.com/questions/20267939/nodejs-write-base64-image-file
-const decodeBase64Image = (data) => {
-  const matches = data.match(/^data:([A-Za-z-+\\/]+);base64,(.+)$/);
-
-  if (matches.length !== 3) {
-    return new Error('Invalid input string');
-  }
-
-  return {
-    type: matches[1],
-    data: Buffer.from(matches[2], 'base64')
-  };
-};
-
 // run the processing sketch
-const gifOut = (filename) => {
-  console.log(`Starting to process ${filename}.`);
+const gifOut = () => {
+  console.log(`Starting to process gif.`);
   exec(processing)
     .then(() => exec(gifIt))
     .then(() => exec(cleanUp));
 };
 
-const main = (payload) => {
-  const imageBuffer = decodeBase64Image(payload);
-  const filename = `cropped.jpg`;
-  return writeFile(filename, imageBuffer.data)
-    .then(() => {
-      return gifOut(filename);
-    })
-    .catch(err => {
-      console.log('err in main catch', err);
-      return err;
-    });
-};
-
-module.exports.gifOut = main;
+module.exports = gifOut;

--- a/server/lib/saveImage.js
+++ b/server/lib/saveImage.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const util = require('util');
+const writeFile = util.promisify(require('fs').writeFile);
+
+// h/t: https://stackoverflow.com/questions/20267939/nodejs-write-base64-image-file
+const decodeBase64Image = (data) => {
+  const matches = data.match(/^data:([A-Za-z-+\\/]+);base64,(.+)$/);
+
+  if (matches.length !== 3) {
+    return new Error(`Invalid input string: ${matches}`);
+  }
+
+  return {
+    type: matches[1],
+    data: Buffer.from(matches[2], 'base64')
+  };
+};
+
+const saveImage = (payload) => {
+  const imageBuffer = decodeBase64Image(payload);
+  const filename = `cropped.jpg`;
+  console.log('~~~Writing file.\n');
+  return writeFile(filename, imageBuffer.data);
+};
+
+module.exports = saveImage;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2242,8 +2242,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boom": {
       "version": "5.2.0",
@@ -3360,6 +3359,18 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
       "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w="
+    },
+    "easyimage": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/easyimage/-/easyimage-3.0.1.tgz",
+      "integrity": "sha512-nBI9c0HQDNSZ10Fe/FHRlP2xmiHnH+RCkMCJvOibpnO4bFstCs0y5rw6chdS3wHpAwYRttrqRXXwxY0EUw4gXA==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "mkdirp": "0.5.1",
+        "shortid": "2.2.8",
+        "tslib": "1.9.0",
+        "typescript": "2.7.2"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -7972,14 +7983,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -10250,6 +10259,11 @@
         "rechoir": "0.6.2"
       }
     },
+    "shortid": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
+      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE="
+    },
     "shot": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
@@ -10946,6 +10960,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/server/package.json
+++ b/server/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "dotenv": "^5.0.0",
+    "easyimage": "^3.0.1",
     "estraverse-fb": "^1.3.2",
     "firebase-admin": "^5.9.0",
     "good": "^7.3.0",


### PR DESCRIPTION
Closes #17 

- Install easyimage lib. Update deps.
- First pass at image crop. Move saving of file from `gifOut` to its own lib file.
- Clean up logging. Adjust dimensions of image cropping. Handle error with trying to emit to hidden div.
- Replace `glitchRes` since p5 needs to run clientside.